### PR TITLE
Folia support: migrate Bukkit scheduler usage to SchedulerUtils

### DIFF
--- a/src/main/java/emanondev/itemtag/actions/DelayedAction.java
+++ b/src/main/java/emanondev/itemtag/actions/DelayedAction.java
@@ -1,10 +1,10 @@
 package emanondev.itemtag.actions;
 
 import emanondev.itemedit.utility.CompleteUtility;
+import emanondev.itemedit.utility.SchedulerUtils;
 import emanondev.itemtag.ItemTag;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,11 +48,8 @@ public class DelayedAction extends Action {
     @Override
     public void execute(Player player, String text) {
         String[] args = text.split(" ");
-        new BukkitRunnable() {
-            public void run() {
-                ActionHandler.handleAction(player, args[1], text.substring(args[0].length() + args[1].length() + 2));
-            }
-        }.runTaskLater(ItemTag.get(), Long.parseLong(args[0]));
+        SchedulerUtils.runLater(ItemTag.get(), player, Long.parseLong(args[0]), () ->
+                ActionHandler.handleAction(player, args[1], text.substring(args[0].length() + args[1].length() + 2)));
     }
 
     @Override

--- a/src/main/java/emanondev/itemtag/activity/action/DelayedActionType.java
+++ b/src/main/java/emanondev/itemtag/activity/action/DelayedActionType.java
@@ -1,12 +1,12 @@
 package emanondev.itemtag.activity.action;
 
+import emanondev.itemedit.utility.SchedulerUtils;
 import emanondev.itemtag.ItemTag;
 import emanondev.itemtag.activity.ActionManager;
 import emanondev.itemtag.activity.ActionType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.jetbrains.annotations.NotNull;
 
 public class DelayedActionType extends ActionType {
@@ -37,12 +37,7 @@ public class DelayedActionType extends ActionType {
 
         @Override
         public boolean execute(@NotNull Player player, @NotNull ItemStack item, Event event) {
-            new BukkitRunnable() {
-                @Override
-                public void run() {
-                    action.execute(player, item, event);
-                }
-            }.runTaskLater(ItemTag.get(), delay);
+            SchedulerUtils.runLater(ItemTag.get(), player, delay, () -> action.execute(player, item, event));
             return true;
         }
     }

--- a/src/main/java/emanondev/itemtag/command/itemtag/Effects.java
+++ b/src/main/java/emanondev/itemtag/command/itemtag/Effects.java
@@ -3,6 +3,7 @@ package emanondev.itemtag.command.itemtag;
 import emanondev.itemedit.aliases.Aliases;
 import emanondev.itemedit.utility.CompleteUtility;
 import emanondev.itemedit.utility.ItemUtils;
+import emanondev.itemedit.utility.SchedulerUtils;
 import emanondev.itemedit.utility.VersionUtils;
 import emanondev.itemtag.EffectsInfo;
 import emanondev.itemtag.ItemTag;
@@ -11,7 +12,6 @@ import emanondev.itemtag.command.ItemTagCommand;
 import emanondev.itemtag.command.ListenerSubCmd;
 import emanondev.itemtag.equipmentchange.EquipmentChangeEvent;
 import emanondev.itemtag.gui.EffectsGui;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -22,7 +22,6 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -269,8 +268,7 @@ public class Effects extends ListenerSubCmd {
 
     @EventHandler
     private void onPlayerRespawn(PlayerRespawnEvent event) {
-        new BukkitRunnable() {
-            public void run() {
+        SchedulerUtils.runLater(ItemTag.get(), event.getPlayer(), 1L, () -> {
                 for (EquipmentSlot slot : ItemTagUtility.getPlayerEquipmentSlots()) {
                     ItemStack equip = getEquip(event.getPlayer(), slot);
                     if (ItemUtils.isAirOrNull(equip))
@@ -301,8 +299,7 @@ public class Effects extends ListenerSubCmd {
                         }
                     }
                 }
-            }
-        }.runTaskLater(ItemTag.get(), 1L); //effect are resetted just after playerrespawnevent
+        }); //effect are resetted just after playerrespawnevent
 
     }
 
@@ -327,7 +324,7 @@ public class Effects extends ListenerSubCmd {
     @EventHandler(ignoreCancelled = true)
     private void event(PlayerItemConsumeEvent event) {
         if (event.getItem().getType() == Material.MILK_BUCKET)
-            Bukkit.getScheduler().runTaskLater(this.getPlugin(), () -> restoreEffects(event.getPlayer()), 1L);
+            SchedulerUtils.runLater(this.getPlugin(), event.getPlayer(), 1L, () -> restoreEffects(event.getPlayer()));
     }
 
     public void restoreEffects(Player p) {

--- a/src/main/java/emanondev/itemtag/command/itemtag/EffectsResurrectListener.java
+++ b/src/main/java/emanondev/itemtag/command/itemtag/EffectsResurrectListener.java
@@ -1,6 +1,6 @@
 package emanondev.itemtag.command.itemtag;
 
-import org.bukkit.Bukkit;
+import emanondev.itemedit.utility.SchedulerUtils;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -21,7 +21,7 @@ public class EffectsResurrectListener implements Listener {
     @EventHandler(ignoreCancelled = true)
     private void event(EntityResurrectEvent event) {
         if (event.getEntity() instanceof Player)
-            Bukkit.getScheduler().runTaskLater(parent.getPlugin(),
+            SchedulerUtils.runLater(parent.getPlugin(), (Player) event.getEntity(), 1L,
                     () -> {
                         List<PotionEffect> l = new ArrayList<>(event.getEntity().getActivePotionEffects());
                         l.forEach((e) -> event.getEntity().removePotionEffect(e.getType()));
@@ -31,8 +31,7 @@ public class EffectsResurrectListener implements Listener {
                                     e.getAmplifier() > event.getEntity().getPotionEffect(e.getType()).getAmplifier())
                                 event.getEntity().addPotionEffect(e);
                         });
-                    }
-                    , 1L);
+                    });
     }
 
 }

--- a/src/main/java/emanondev/itemtag/command/itemtag/WearPermission.java
+++ b/src/main/java/emanondev/itemtag/command/itemtag/WearPermission.java
@@ -7,11 +7,11 @@ import emanondev.itemedit.command.AbstractCommand;
 import emanondev.itemedit.utility.CompleteUtility;
 import emanondev.itemedit.utility.InventoryUtils;
 import emanondev.itemedit.utility.ItemUtils;
+import emanondev.itemedit.utility.SchedulerUtils;
 import emanondev.itemtag.ItemTag;
 import emanondev.itemtag.TagItem;
 import emanondev.itemtag.command.ListenerSubCmd;
 import emanondev.itemtag.equipmentchange.EquipmentChangeEvent;
-import org.bukkit.Bukkit;
 import org.bukkit.Sound;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -114,7 +114,7 @@ public class WearPermission extends ListenerSubCmd {
             return;
         }
 
-        Bukkit.getScheduler().runTaskLater(getPlugin(), () -> {
+        SchedulerUtils.runLater(getPlugin(), player, 1L, () -> {
             if (!player.isOnline())
                 return;
             ItemStack originalItem = InventoryUtils.getItem(player, event.getSlotType());
@@ -141,7 +141,7 @@ public class WearPermission extends ListenerSubCmd {
                 api.setCooldown(player,cooldownKey,1, TimeUnit.SECONDS);
                 Util.sendMessage(player, UtilsString.fix(tagItem.getString(WEARMSG_KEY), player, true, "%permission%", perm));
             }
-        }, 1L);
+        });
 
     }
 

--- a/src/main/java/emanondev/itemtag/command/itemtag/customflags/EquipmentFlag.java
+++ b/src/main/java/emanondev/itemtag/command/itemtag/customflags/EquipmentFlag.java
@@ -2,10 +2,10 @@ package emanondev.itemtag.command.itemtag.customflags;
 
 import emanondev.itemedit.utility.InventoryUtils;
 import emanondev.itemedit.utility.ItemUtils;
+import emanondev.itemedit.utility.SchedulerUtils;
 import emanondev.itemtag.ItemTag;
 import emanondev.itemtag.command.itemtag.Flag;
 import emanondev.itemtag.equipmentchange.EquipmentChangeEvent;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.event.EventHandler;
@@ -48,7 +48,7 @@ public class EquipmentFlag extends CustomFlag {
         if (this.getValue(ItemTag.getTagItem(event.getTo()))) {
             return;
         }
-        Bukkit.getScheduler().runTaskLater(getPlugin(), () -> {
+        SchedulerUtils.runLater(getPlugin(), event.getPlayer(), 1L, () -> {
             if (!event.getPlayer().isOnline()) {
                 return;
             }
@@ -94,6 +94,6 @@ public class EquipmentFlag extends CustomFlag {
             InventoryUtils.giveAmount(event.getPlayer(), item, item.getAmount(), InventoryUtils.ExcessMode.DROP_EXCESS);
             ItemTag.get().getEquipChangeListener().onEquipChange(event.getPlayer(), EquipmentChangeEvent.EquipMethod.UNKNOWN
                     , event.getSlotType(), item, null);
-        }, 1L);
+        });
     }
 }

--- a/src/main/java/emanondev/itemtag/command/itemtag/customflags/RenamableOld.java
+++ b/src/main/java/emanondev/itemtag/command/itemtag/customflags/RenamableOld.java
@@ -1,9 +1,10 @@
 package emanondev.itemtag.command.itemtag.customflags;
 
+import emanondev.itemedit.utility.SchedulerUtils;
 import emanondev.itemtag.ItemTag;
 import emanondev.itemtag.command.itemtag.Flag;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -27,12 +28,12 @@ public class RenamableOld extends CustomFlag {
         }
         if (ItemTag.getTagItem(event.getInventory().getItem(0)).hasBooleanTag(RENAMABLE_KEY) ||
                 ItemTag.getTagItem(event.getInventory().getItem(1)).hasBooleanTag(RENAMABLE_KEY)) {
-            Bukkit.getScheduler().runTaskLater(ItemTag.get(), () -> {
+            SchedulerUtils.runLater(ItemTag.get(), (Player) event.getWhoClicked(), 1L, () -> {
                 if (ItemTag.getTagItem(event.getInventory().getItem(0)).hasBooleanTag(RENAMABLE_KEY) ||
                         ItemTag.getTagItem(event.getInventory().getItem(1)).hasBooleanTag(RENAMABLE_KEY)) {
                     event.getInventory().setItem(2, null);
                 }
-            }, 1L);
+            });
             if (event.getSlot() == 2) {
                 event.setCancelled(true);
             }

--- a/src/main/java/emanondev/itemtag/command/itemtag/customflags/Usable.java
+++ b/src/main/java/emanondev/itemtag/command/itemtag/customflags/Usable.java
@@ -1,10 +1,10 @@
 package emanondev.itemtag.command.itemtag.customflags;
 
 import emanondev.itemedit.utility.InventoryUtils;
+import emanondev.itemedit.utility.SchedulerUtils;
 import emanondev.itemedit.utility.VersionUtils;
 import emanondev.itemtag.ItemTag;
 import emanondev.itemtag.command.itemtag.Flag;
-import org.bukkit.Bukkit;
 import org.bukkit.FluidCollisionMode;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -37,14 +37,14 @@ public class Usable extends CustomFlag {
                         b = event.getPlayer().getTargetBlockExact(7, FluidCollisionMode.SOURCE_ONLY);
                     } else
                         b = null;
-                    Bukkit.getScheduler().runTaskLater(ItemTag.get(), () -> { //TODO folia fix
+                    SchedulerUtils.runLater(ItemTag.get(), event.getPlayer(), 1L, () -> {
                         if (!VersionUtils.isVersionAfter(1, 20)) {
                             InventoryUtils.updateView(event.getPlayer());
                         }
                         if (b != null) {//reduce clientside visual glich on liquids only for 1.14+
                             event.getPlayer().sendBlockChange(b.getLocation(), b.getBlockData());
                         }
-                    }, 1L);
+                    });
                 }
             default:
         }

--- a/src/main/java/emanondev/itemtag/equipmentchange/EquipmentChangeListener.java
+++ b/src/main/java/emanondev/itemtag/equipmentchange/EquipmentChangeListener.java
@@ -2,7 +2,6 @@ package emanondev.itemtag.equipmentchange;
 
 import emanondev.itemedit.utility.InventoryUtils;
 import emanondev.itemedit.utility.ItemUtils;
-import emanondev.itemtag.ItemTag;
 import emanondev.itemtag.ItemTagUtility;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -110,10 +109,9 @@ public class EquipmentChangeListener extends EquipmentChangeListenerBase {
                     onEquipChange(p, EquipmentChangeEvent.EquipMethod.INVENTORY_MOVE_TO_OTHER_INVENTORY, slot, null, event.getCurrentItem());
                 if (clickedSlot == null || clickedSlot == EquipmentSlot.HAND)
                     new SlotCheck(p, EquipmentChangeEvent.EquipMethod.INVENTORY_MOVE_TO_OTHER_INVENTORY, EquipmentSlot.HAND)
-                            .runTaskLater(ItemTag.get(), 1L);
+                            .schedule();
                 else
-                    new SlotCheck(p, EquipmentChangeEvent.EquipMethod.INVENTORY_MOVE_TO_OTHER_INVENTORY, clickedSlot).runTaskLater(ItemTag.get(),
-                            1L);
+                    new SlotCheck(p, EquipmentChangeEvent.EquipMethod.INVENTORY_MOVE_TO_OTHER_INVENTORY, clickedSlot).schedule();
                 return;
             }
             case COLLECT_TO_CURSOR:
@@ -126,7 +124,7 @@ public class EquipmentChangeListener extends EquipmentChangeListenerBase {
                 else if (event.getCursor().isSimilar(getEquip(p, EquipmentSlot.HAND)))
                     slots.add(EquipmentSlot.HAND);
                 if (!slots.isEmpty())
-                    new SlotCheck(p, EquipmentChangeEvent.EquipMethod.INVENTORY_COLLECT_TO_CURSOR, slots).runTaskLater(ItemTag.get(), 1L);
+                    new SlotCheck(p, EquipmentChangeEvent.EquipMethod.INVENTORY_COLLECT_TO_CURSOR, slots).schedule();
                 return;
             case PICKUP_SOME:
             case UNKNOWN:
@@ -255,6 +253,6 @@ public class EquipmentChangeListener extends EquipmentChangeListenerBase {
         for (int i = 0; i < p.getInventory().getHeldItemSlot(); i++)
             if (ItemUtils.isAirOrNull(p.getInventory().getItem(i)))
                 return;
-        new SlotCheck(p, EquipmentChangeEvent.EquipMethod.PICKUP, EquipmentSlot.HAND).runTaskLater(ItemTag.get(), 1L);
+        new SlotCheck(p, EquipmentChangeEvent.EquipMethod.PICKUP, EquipmentSlot.HAND).schedule();
     }
 }

--- a/src/main/java/emanondev/itemtag/equipmentchange/EquipmentChangeListenerBase.java
+++ b/src/main/java/emanondev/itemtag/equipmentchange/EquipmentChangeListenerBase.java
@@ -1,6 +1,7 @@
 package emanondev.itemtag.equipmentchange;
 
 import emanondev.itemedit.utility.ItemUtils;
+import emanondev.itemedit.utility.SchedulerUtils;
 import emanondev.itemedit.utility.VersionUtils;
 import emanondev.itemtag.ItemTag;
 import emanondev.itemtag.ItemTagUtility;
@@ -25,19 +26,26 @@ import org.bukkit.scheduler.BukkitRunnable;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 public abstract class EquipmentChangeListenerBase implements Listener {
 
-    protected final HashMap<Player, EnumMap<EquipmentSlot, ItemStack>> equips = new HashMap<>();
-    protected final HashSet<Player> clickDrop = new HashSet<>();
+    // On Folia equipment is read/written from each player's own region thread, so the
+    // backing collections must be thread-safe (mirrors ActionHandler's Folia handling).
+    protected final Map<Player, EnumMap<EquipmentSlot, ItemStack>> equips =
+            VersionUtils.hasFoliaAPI() ? new ConcurrentHashMap<>() : new HashMap<>();
+    protected final Set<Player> clickDrop =
+            VersionUtils.hasFoliaAPI() ? ConcurrentHashMap.newKeySet() : new HashSet<>();
     private int maxCheckedPlayerPerTick = 5;
+    private long timerCheckFrequencyTicks = 10;
     private TimerCheckTask timerTask = null;
+    private boolean foliaPollRunning = false;
 
     public void reload() {
         if (timerTask != null) {
             timerTask.cancel();
         }
-        long timerCheckFrequencyTicks = Math.max(5, ItemTag.get().getConfig().getInteger("equipment_change.frequency_ticks", 10));
+        timerCheckFrequencyTicks = Math.max(5, ItemTag.get().getConfig().getInteger("equipment_change.frequency_ticks", 10));
         maxCheckedPlayerPerTick = Math.max(1, ItemTag.get().getConfig().getInteger("equipment_change.max_checked_players_per_tick", 5));
         for (Player p : new ArrayList<>(equips.keySet())) {
             untrackPlayer(p);
@@ -48,9 +56,56 @@ public abstract class EquipmentChangeListenerBase implements Listener {
             trackPlayer(p);
         }
 
-        timerTask = new TimerCheckTask();
-        timerTask.runTaskTimer(ItemTag.get(), timerCheckFrequencyTicks, timerCheckFrequencyTicks);
+        if (VersionUtils.hasFoliaAPI()) {
+            // Folia has no global repeating scheduler usable here; self-reschedule via
+            // SchedulerUtils and fan out each player check to its own region thread.
+            if (!foliaPollRunning) {
+                foliaPollRunning = true;
+                scheduleFoliaPoll();
+            }
+        } else {
+            timerTask = new TimerCheckTask();
+            timerTask.runTaskTimer(ItemTag.get(), timerCheckFrequencyTicks, timerCheckFrequencyTicks);
+        }
 
+    }
+
+    private void scheduleFoliaPoll() {
+        SchedulerUtils.runLater(ItemTag.get(), timerCheckFrequencyTicks, () -> {
+            if (!foliaPollRunning) {
+                return;
+            }
+            for (Player p : new ArrayList<>(equips.keySet())) {
+                if (!p.isOnline()) {
+                    untrackPlayer(p);
+                    continue;
+                }
+                if (p.hasMetadata("BOT")) {
+                    continue;
+                }
+                SchedulerUtils.run(ItemTag.get(), p, () -> checkPlayerEquipment(p));
+            }
+            scheduleFoliaPoll();
+        });
+    }
+
+    private void checkPlayerEquipment(Player p) {
+        if (!p.isOnline()) {
+            untrackPlayer(p);
+            return;
+        }
+        trackPlayer(p);
+        EnumMap<EquipmentSlot, ItemStack> map = equips.get(p);
+        if (map == null) {
+            return;
+        }
+        for (EquipmentSlot slot : ItemTagUtility.getPlayerEquipmentSlots()) {
+            ItemStack newItem = getEquip(p, slot);
+            ItemStack oldItem = map.get(slot);
+            if (!isSimilarIgnoreDamage(oldItem, newItem)) {
+                onEquipChange(p, EquipmentChangeEvent.EquipMethod.UNKNOWN, slot, oldItem, newItem);
+            }
+        }
     }
 
     public abstract boolean isSimilarIgnoreDamage(ItemStack item, ItemStack item2);
@@ -111,7 +166,7 @@ public abstract class EquipmentChangeListenerBase implements Listener {
         if (!equips.containsKey(event.getPlayer()))
             return; // some plugins teleport players just after login, before join this listener
         new SlotCheck(event.getPlayer(), EquipmentChangeEvent.EquipMethod.PLUGIN_WORLD_CHANGE, ItemTagUtility.getPlayerEquipmentSlots())
-                .runTaskLater(ItemTag.get(), 1L);
+                .schedule();
     }
 
     protected void handle(PlayerRespawnEvent event) {
@@ -155,7 +210,7 @@ public abstract class EquipmentChangeListenerBase implements Listener {
             onEquipChange(e.getPlayer(), EquipmentChangeEvent.EquipMethod.BROKE, slots.get(0), e.getBrokenItem(), null);
             return;
         }
-        new SlotCheck(e.getPlayer(), EquipmentChangeEvent.EquipMethod.BROKE, slots).runTaskLater(ItemTag.get(), 1L);
+        new SlotCheck(e.getPlayer(), EquipmentChangeEvent.EquipMethod.BROKE, slots).schedule();
     }
 
     protected void handle(PlayerArmorStandManipulateEvent event) {
@@ -215,7 +270,7 @@ public abstract class EquipmentChangeListenerBase implements Listener {
             onEquipChange(event.getPlayer(), EquipmentChangeEvent.EquipMethod.SHEEP_COLOR, slot, handItem, null);
             return;
         }
-        new SlotCheck(event.getPlayer(), EquipmentChangeEvent.EquipMethod.USE_ON_ENTITY, slot).runTaskLater(ItemTag.get(), 1L);
+        new SlotCheck(event.getPlayer(), EquipmentChangeEvent.EquipMethod.USE_ON_ENTITY, slot).schedule();
     }
 
     protected void handle(PlayerInteractEvent e) {
@@ -238,15 +293,15 @@ public abstract class EquipmentChangeListenerBase implements Listener {
                     if (e.getPlayer().getGameMode() != GameMode.CREATIVE)
                         onEquipChange(e.getPlayer(), EquipmentChangeEvent.EquipMethod.RIGHT_CLICK, slot, e.getItem(), null);
                 } else if (e.getItem().getAmount() == 1)
-                    new SlotCheck(e.getPlayer(), EquipmentChangeEvent.EquipMethod.USE, slot).runTaskLater(ItemTag.get(), 1L);
+                    new SlotCheck(e.getPlayer(), EquipmentChangeEvent.EquipMethod.USE, slot).schedule();
                 return;
             case RIGHT_CLICK_BLOCK:
                 if (e.useItemInHand() == Event.Result.DENY)
                     return;
                 if (type != null && ItemUtils.isAirOrNull(getEquip(e.getPlayer(), type))) {
-                    new SlotCheck(e.getPlayer(), EquipmentChangeEvent.EquipMethod.RIGHT_CLICK, slot, type).runTaskLater(ItemTag.get(), 1L);
+                    new SlotCheck(e.getPlayer(), EquipmentChangeEvent.EquipMethod.RIGHT_CLICK, slot, type).schedule();
                 } else if (e.getItem().getAmount() == 1)
-                    new SlotCheck(e.getPlayer(), EquipmentChangeEvent.EquipMethod.USE, slot).runTaskLater(ItemTag.get(), 1L);
+                    new SlotCheck(e.getPlayer(), EquipmentChangeEvent.EquipMethod.USE, slot).schedule();
                 return;
             default:
                 return;
@@ -269,11 +324,11 @@ public abstract class EquipmentChangeListenerBase implements Listener {
             onEquipChange(event.getPlayer(), EquipmentChangeEvent.EquipMethod.CONSUME, slots.get(0), event.getItem(),
                     event.getItem().getType() == Material.MILK_BUCKET ? new ItemStack(Material.BUCKET) : null);
         else if (slots.size() > 1)
-            new SlotCheck(event.getPlayer(), EquipmentChangeEvent.EquipMethod.CONSUME, slots).runTaskLater(ItemTag.get(), 1L);
+            new SlotCheck(event.getPlayer(), EquipmentChangeEvent.EquipMethod.CONSUME, slots).schedule();
         else // 3rd party plugin
             if (VersionUtils.isVersionAfter(1, 9))// safe
                 new SlotCheck(event.getPlayer(), EquipmentChangeEvent.EquipMethod.CONSUME,
-                        Arrays.asList(EquipmentSlot.HAND, EquipmentSlot.OFF_HAND)).runTaskLater(ItemTag.get(), 1L);
+                        Arrays.asList(EquipmentSlot.HAND, EquipmentSlot.OFF_HAND)).schedule();
     }
 
     protected void handle(PlayerItemHeldEvent event) {
@@ -466,11 +521,18 @@ public abstract class EquipmentChangeListenerBase implements Listener {
 
     }
 
-    protected class SlotCheck extends BukkitRunnable {
+    protected class SlotCheck implements Runnable {
 
         private final EnumSet<EquipmentSlot> slots = EnumSet.noneOf(EquipmentSlot.class);
         private final Player p;
         private final EquipmentChangeEvent.EquipMethod method;
+
+        /**
+         * Runs this check one tick later on the player's region thread (Folia-safe).
+         */
+        public void schedule() {
+            SchedulerUtils.runLater(ItemTag.get(), p, 1L, this);
+        }
 
         public SlotCheck(Player p, EquipmentChangeEvent.EquipMethod method, EquipmentSlot... slots) {
             if (slots == null || slots.length == 0 || p == null || method == null)

--- a/src/main/java/emanondev/itemtag/equipmentchange/EquipmentChangeListenerUpTo1_13.java
+++ b/src/main/java/emanondev/itemtag/equipmentchange/EquipmentChangeListenerUpTo1_13.java
@@ -3,8 +3,6 @@ package emanondev.itemtag.equipmentchange;
 import emanondev.itemedit.utility.InventoryUtils;
 import emanondev.itemedit.utility.ItemUtils;
 import emanondev.itemedit.utility.VersionUtils;
-import emanondev.itemtag.ItemTag;
-import emanondev.itemtag.ItemTagUtility;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
@@ -202,10 +200,9 @@ public class EquipmentChangeListenerUpTo1_13 extends EquipmentChangeListenerBase
                     onEquipChange(p, EquipmentChangeEvent.EquipMethod.INVENTORY_MOVE_TO_OTHER_INVENTORY, slot, null, event.getCurrentItem());
                 if (clickedSlot == null || clickedSlot == EquipmentSlot.HAND)
                     new SlotCheck(p, EquipmentChangeEvent.EquipMethod.INVENTORY_MOVE_TO_OTHER_INVENTORY, EquipmentSlot.HAND)
-                            .runTaskLater(ItemTag.get(), 1L);
+                            .schedule();
                 else
-                    new SlotCheck(p, EquipmentChangeEvent.EquipMethod.INVENTORY_MOVE_TO_OTHER_INVENTORY, clickedSlot).runTaskLater(ItemTag.get(),
-                            1L);
+                    new SlotCheck(p, EquipmentChangeEvent.EquipMethod.INVENTORY_MOVE_TO_OTHER_INVENTORY, clickedSlot).schedule();
                 return;
             }
             case COLLECT_TO_CURSOR:
@@ -218,7 +215,7 @@ public class EquipmentChangeListenerUpTo1_13 extends EquipmentChangeListenerBase
                 else if (event.getCursor().isSimilar(getEquip(p, EquipmentSlot.HAND)))
                     slots.add(EquipmentSlot.HAND);
                 if (!slots.isEmpty())
-                    new SlotCheck(p, EquipmentChangeEvent.EquipMethod.INVENTORY_COLLECT_TO_CURSOR, slots).runTaskLater(ItemTag.get(), 1L);
+                    new SlotCheck(p, EquipmentChangeEvent.EquipMethod.INVENTORY_COLLECT_TO_CURSOR, slots).schedule();
                 return;
             case PICKUP_SOME:
             case UNKNOWN:
@@ -248,7 +245,7 @@ public class EquipmentChangeListenerUpTo1_13 extends EquipmentChangeListenerBase
         for (int i = 0; i < event.getPlayer().getInventory().getHeldItemSlot(); i++)
             if (ItemUtils.isAirOrNull(event.getPlayer().getInventory().getItem(i)))
                 return;
-        new SlotCheck(event.getPlayer(), EquipmentChangeEvent.EquipMethod.PICKUP, EquipmentSlot.HAND).runTaskLater(ItemTag.get(), 1L);
+        new SlotCheck(event.getPlayer(), EquipmentChangeEvent.EquipMethod.PICKUP, EquipmentSlot.HAND).schedule();
     }
 
     private boolean isUbreakable(ItemMeta meta) {

--- a/src/main/java/emanondev/itemtag/equipmentchange/EquipmentChangeListenerUpTo1_8.java
+++ b/src/main/java/emanondev/itemtag/equipmentchange/EquipmentChangeListenerUpTo1_8.java
@@ -2,7 +2,6 @@ package emanondev.itemtag.equipmentchange;
 
 import emanondev.itemedit.utility.InventoryUtils;
 import emanondev.itemedit.utility.ItemUtils;
-import emanondev.itemtag.ItemTag;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -190,10 +189,9 @@ public class EquipmentChangeListenerUpTo1_8 extends EquipmentChangeListenerBase 
                     onEquipChange(p, EquipmentChangeEvent.EquipMethod.INVENTORY_MOVE_TO_OTHER_INVENTORY, slot, null, event.getCurrentItem());
                 if (clickedSlot == null || clickedSlot == EquipmentSlot.HAND)
                     new SlotCheck(p, EquipmentChangeEvent.EquipMethod.INVENTORY_MOVE_TO_OTHER_INVENTORY, EquipmentSlot.HAND)
-                            .runTaskLater(ItemTag.get(), 1L);
+                            .schedule();
                 else
-                    new SlotCheck(p, EquipmentChangeEvent.EquipMethod.INVENTORY_MOVE_TO_OTHER_INVENTORY, clickedSlot).runTaskLater(ItemTag.get(),
-                            1L);
+                    new SlotCheck(p, EquipmentChangeEvent.EquipMethod.INVENTORY_MOVE_TO_OTHER_INVENTORY, clickedSlot).schedule();
                 return;
             }
             case COLLECT_TO_CURSOR:
@@ -206,7 +204,7 @@ public class EquipmentChangeListenerUpTo1_8 extends EquipmentChangeListenerBase 
                 else if (event.getCursor().isSimilar(getEquip(p, EquipmentSlot.HAND)))
                     slots.add(EquipmentSlot.HAND);
                 if (!slots.isEmpty())
-                    new SlotCheck(p, EquipmentChangeEvent.EquipMethod.INVENTORY_COLLECT_TO_CURSOR, slots).runTaskLater(ItemTag.get(), 1L);
+                    new SlotCheck(p, EquipmentChangeEvent.EquipMethod.INVENTORY_COLLECT_TO_CURSOR, slots).schedule();
                 return;
             case PICKUP_SOME:
             case UNKNOWN:
@@ -224,7 +222,7 @@ public class EquipmentChangeListenerUpTo1_8 extends EquipmentChangeListenerBase 
         for (int i = 0; i < event.getPlayer().getInventory().getHeldItemSlot(); i++)
             if (ItemUtils.isAirOrNull(event.getPlayer().getInventory().getItem(i)))
                 return;
-        new SlotCheck(event.getPlayer(), EquipmentChangeEvent.EquipMethod.PICKUP, EquipmentSlot.HAND).runTaskLater(ItemTag.get(), 1L);
+        new SlotCheck(event.getPlayer(), EquipmentChangeEvent.EquipMethod.PICKUP, EquipmentSlot.HAND).schedule();
     }
 
     private boolean isUbreakable(ItemMeta meta) {


### PR DESCRIPTION
## Why

`plugin.yml` already declares `folia-supported: true`, but the plugin still scheduled work through the **global `BukkitScheduler`** / `BukkitRunnable`, which throws on Folia. There was even a leftover `//TODO folia fix` in `Usable`. On Folia `reload()` would also blow up because `EquipmentChangeListenerBase` started a `runTaskTimer` on the global scheduler.

## What

Migrated every scheduler call to ItemEdit's Folia-aware `SchedulerUtils`, scoping each task to the player it acts on so it runs on that entity's region thread.

**One-shot delayed tasks** (`runTaskLater` / `BukkitRunnable`):
- `customflags/Usable` (removes the `//TODO folia fix`)
- `customflags/EquipmentFlag`
- `customflags/RenamableOld`
- `command/itemtag/WearPermission`
- `command/itemtag/EffectsResurrectListener`
- `command/itemtag/Effects` (respawn + milk-bucket consume)
- `actions/DelayedAction`
- `activity/action/DelayedActionType`

**Equipment change listener:**
- `SlotCheck` no longer extends `BukkitRunnable` — it implements `Runnable` and exposes `schedule()` backed by `SchedulerUtils.runLater(plugin, player, 1L, this)`. All `new SlotCheck(...).runTaskLater(...)` call sites (Base + `EquipmentChangeListener` + `UpTo1_13` + `UpTo1_8`) now call `.schedule()`.
- The periodic equipment poll keeps the existing `BukkitRunnable` timer **off Folia** (unchanged behaviour, including `max_checked_players_per_tick` spreading). **On Folia** it self-reschedules through `SchedulerUtils` and fans each player's check out to that player's own region thread.
- `equips` / `clickDrop` are backed by thread-safe collections on Folia (mirrors the existing `ActionHandler` `ConcurrentHashMap` handling), since they are now touched from per-player region threads.

## Notes
- No new dependency: `SchedulerUtils` ships with ItemEdit (already a `compile` dependency).
- Non-Folia behaviour is intentionally left identical — only the Folia branch is new.
- Builds cleanly with `mvn package` against spigot-api 1.21.x. I don't have a Folia server to runtime-test the equipment-poll path, so that part would benefit from a check on a live Folia instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)